### PR TITLE
arm: dts: qcom: lumia: correct dempsey's brand

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -958,7 +958,7 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-ipq8064-ap148.dtb \
 	qcom-ipq8064-rb3011.dtb \
 	qcom-msm8226-nokia-lumia-tesla.dtb \
-	qcom-msm8226-nokia-lumia-dempsey.dtb \
+	qcom-msm8226-microsoft-lumia-dempsey.dtb \
 	qcom-msm8226-samsung-s3ve3g.dtb \
 	qcom-msm8660-surf.dtb \
 	qcom-msm8960-cdp.dtb \

--- a/arch/arm/boot/dts/qcom-msm8226-microsoft-lumia-dempsey.dts
+++ b/arch/arm/boot/dts/qcom-msm8226-microsoft-lumia-dempsey.dts
@@ -8,6 +8,6 @@
 #include "qcom-msm8226-nokia-lumia-common.dtsi"
 
 / {
-	model = "Nokia Lumia 640";
+	model = "Microsoft Lumia 640";
 	compatible = "lumia,dempsey","qcom,msm8226";
 };


### PR DESCRIPTION
The Lumia 640 is actually branded as Microsoft instead of Nokia, so reflect that here.

Signed-off-by: Jack Matthews <jack@matthews-net.org.uk>