### PR TITLE
arm: dts: qcom: nokia-lumia-moneypenny: add initial device tree

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -958,6 +958,7 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-ipq8064-ap148.dtb \
 	qcom-ipq8064-rb3011.dtb \
 	qcom-msm8226-nokia-lumia-tesla.dtb \
+	qcom-msm8226-nokia-lumia-moneypenny.dtb \
 	qcom-msm8226-microsoft-lumia-dempsey.dtb \
 	qcom-msm8226-samsung-s3ve3g.dtb \
 	qcom-msm8660-surf.dtb \

--- a/arch/arm/boot/dts/qcom-msm8226-nokia-lumia-moneypenny.dts
+++ b/arch/arm/boot/dts/qcom-msm8226-nokia-lumia-moneypenny.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2021, Dominik Kobinski <Dominduchami@outlook.com>
+ * Copyright (c) 2021, Ivaylo Ivanov <ivo.ivanov@null.net>
+ */
+/dts-v1/;
+
+#include "qcom-msm8226-nokia-lumia-common.dtsi"
+
+/ {
+	model = "Nokia Lumia 630";
+	compatible = "lumia,moneypenny","qcom,msm8226";
+	qcom,msm-id = <158 0x20000>;
+	qcom,board-id = <8 0x0>;
+};


### PR DESCRIPTION
Adds initial support for moneypenny.
Since moneypenny boots mainline through littlekernel, we need qcom,msm-id and qcom,board-id values.

Signed-off-by: Jack Matthews <jack@matthews-net.org.uk>